### PR TITLE
alias ImageSanitize::class to 'image-sanitize'

### DIFF
--- a/src/ServiceProviders/ImageSanitizeServiceProvider.php
+++ b/src/ServiceProviders/ImageSanitizeServiceProvider.php
@@ -30,8 +30,11 @@ class ImageSanitizeServiceProvider extends ServiceProvider
         $this->app->singleton(ImageSanitize::class, function () {
             return new ImageSanitize(new PatternList);
         });
+
         $this->app->singleton(RequestHandler::class, function () {
             return new RequestHandler(new MimeTypeList);
         });
+
+        $this->app->alias(ImageSanitize::class, 'image-sanitize');
     }
 }

--- a/tests/ImageSanitizeTest.php
+++ b/tests/ImageSanitizeTest.php
@@ -3,6 +3,7 @@
 namespace LaravelAt\ImageSanitize\Tests;
 
 use LaravelAt\ImageSanitize\ImageSanitize;
+use LaravelAt\ImageSanitize\Facades\ImageSanitizeFacade;
 
 class ImageSanitizeTest extends TestCase
 {
@@ -14,6 +15,8 @@ class ImageSanitizeTest extends TestCase
         $this->assertTrue(
             app(ImageSanitize::class)->detect($content)
         );
+
+        $this->assertTrue(ImageSanitizeFacade::detect($content));
     }
 
     /** @test */
@@ -24,5 +27,7 @@ class ImageSanitizeTest extends TestCase
         $secureImage = app(ImageSanitize::class)->sanitize($content);
 
         $this->assertFalse(app(ImageSanitize::class)->detect($secureImage));
+
+        $this->assertFalse(ImageSanitizeFacade::detect($secureImage));
     }
 }


### PR DESCRIPTION
This PR fixes `ImageSanitizeFacade` by aliasing `ImageSanitize::class` to `image-sanitize`.

Also, tests considering Facade usage were written.