### PR TITLE
Add PHP7.2 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.2
   - 7.3
 
 env:


### PR DESCRIPTION
`composer.json` has PHP7.2 as a requirement, so it would be nice to have Travis running tests on this version as well.