### PR TITLE
A small autumn clean-up

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,0 @@
-<?php
-
-return [
-    'malicious_patterns' => [
-        //
-    ],
-];

--- a/src/Facades/ImageSanitizeFacade.php
+++ b/src/Facades/ImageSanitizeFacade.php
@@ -3,6 +3,7 @@
 namespace LaravelAt\ImageSanitize\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use LaravelAt\ImageSanitize\ImageSanitize;
 
 /**
  * @see \LaravelAt\ImageSanitize\ImageSanitize
@@ -16,6 +17,6 @@ class ImageSanitizeFacade extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'image-sanitize';
+        return ImageSanitize::class;
     }
 }

--- a/src/ImageSanitize.php
+++ b/src/ImageSanitize.php
@@ -2,18 +2,25 @@
 
 namespace LaravelAt\ImageSanitize;
 
+use Intervention\Image\Image;
+use Intervention\Image\ImageManager;
 use LaravelAt\ImageSanitize\Lists\PatternList;
-use Intervention\Image\ImageManagerStatic as Image;
 
 class ImageSanitize
 {
     /**
+     * @var \Intervention\Image\ImageManager
+     */
+    protected $imageManager;
+
+    /**
      * @var PatternList
      */
-    private $patternList;
+    protected $patternList;
 
-    public function __construct(PatternList $patternList)
+    public function __construct(ImageManager $imageManager, PatternList $patternList)
     {
+        $this->imageManager = $imageManager;
         $this->patternList = $patternList;
     }
 
@@ -28,8 +35,8 @@ class ImageSanitize
         return false;
     }
 
-    public function sanitize(string $content)
+    public function sanitize(string $content): Image
     {
-        return Image::make($content)->encode(null, 100);
+        return $this->imageManager->make($content)->encode(null, 100);
     }
 }

--- a/src/ImageSanitizeMiddleware.php
+++ b/src/ImageSanitizeMiddleware.php
@@ -7,15 +7,25 @@ use Closure;
 class ImageSanitizeMiddleware
 {
     /**
+     * @var \LaravelAt\ImageSanitize\RequestHandler
+     */
+    protected $requestHandler;
+
+    public function __construct(RequestHandler $requestHandler)
+    {
+        $this->requestHandler = $requestHandler;
+    }
+
+    /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure $next
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure                 $next
      * @return mixed
      */
     public function handle($request, Closure $next)
     {
-        app(RequestHandler::class)->handle($request);
+        $this->requestHandler->handle($request);
 
         return $next($request);
     }

--- a/src/ServiceProviders/ImageSanitizeServiceProvider.php
+++ b/src/ServiceProviders/ImageSanitizeServiceProvider.php
@@ -5,8 +5,6 @@ namespace LaravelAt\ImageSanitize\ServiceProviders;
 use Illuminate\Support\ServiceProvider;
 use LaravelAt\ImageSanitize\ImageSanitize;
 use LaravelAt\ImageSanitize\RequestHandler;
-use LaravelAt\ImageSanitize\Lists\PatternList;
-use LaravelAt\ImageSanitize\Lists\MimeTypeList;
 
 class ImageSanitizeServiceProvider extends ServiceProvider
 {
@@ -15,9 +13,7 @@ class ImageSanitizeServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->publishes([
-            __DIR__.'/../../config/config.php' => config_path('image-sanitize.php'),
-        ], 'config');
+        //
     }
 
     /**
@@ -25,13 +21,7 @@ class ImageSanitizeServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'image-sanitize');
-
-        $this->app->singleton(ImageSanitize::class, function () {
-            return new ImageSanitize(new PatternList);
-        });
-        $this->app->singleton(RequestHandler::class, function () {
-            return new RequestHandler(new MimeTypeList);
-        });
+        $this->app->singleton(ImageSanitize::class);
+        $this->app->singleton(RequestHandler::class);
     }
 }

--- a/tests/ImageSanitizeTest.php
+++ b/tests/ImageSanitizeTest.php
@@ -12,7 +12,7 @@ class ImageSanitizeTest extends TestCase
         $content = file_get_contents(__DIR__.'/stubs/exploit.jpeg');
 
         $this->assertTrue(
-            app(ImageSanitize::class)->detect($content)
+            $this->app->make(ImageSanitize::class)->detect($content)
         );
     }
 
@@ -21,8 +21,8 @@ class ImageSanitizeTest extends TestCase
     {
         $content = file_get_contents(__DIR__.'/stubs/exploit.jpeg');
 
-        $secureImage = app(ImageSanitize::class)->sanitize($content);
+        $secureImage = $this->app->make(ImageSanitize::class)->sanitize($content);
 
-        $this->assertFalse(app(ImageSanitize::class)->detect($secureImage));
+        $this->assertFalse($this->app->make(ImageSanitize::class)->detect($secureImage));
     }
 }

--- a/tests/RequestHandlerTest.php
+++ b/tests/RequestHandlerTest.php
@@ -58,6 +58,8 @@ class RequestHandlerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->handler = $this->app->make(RequestHandler::class);
 
         $this->sanitizer = $this->app->make(ImageSanitize::class);

--- a/tests/RequestHandlerTest.php
+++ b/tests/RequestHandlerTest.php
@@ -58,8 +58,8 @@ class RequestHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->handler = app(RequestHandler::class);
+        $this->handler = $this->app->make(RequestHandler::class);
 
-        $this->sanitizer = app(ImageSanitize::class);
+        $this->sanitizer = $this->app->make(ImageSanitize::class);
     }
 }


### PR DESCRIPTION
Changes:
- Removed unused config file.
- Replaced facade accessor with `ImageSanitize::class` instead of `image-sanitize`.
- Removed explicit singleton registry to make it easier to register your own `PatternList` and `MimeTypeList`, this change makes it so that the only thing to do when override any of these 2 instances is registering it in the container `$this->app->bind(PatternList::class, MyOverriddenPatternList::class)`.
- Applied Dependency Injection where possible.