### PR TITLE
added FQCN to Middleware in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Register the `ImageSanitizeMiddleware` in your `App\Http\Kernel` class
 ``` php
 protected $routeMiddleware = [
     // ...
-    'image-sanitize' => ImageSanitizeMiddleware::class,
+    'image-sanitize' => \LaravelAt\ImageSanitize\ImageSanitizeMiddleware::class,
 ];
 
 ```


### PR DESCRIPTION
As a result of a user confusion, we are being more explicit and thus using the FQCN in the README's integration example.