### PR TITLE
[3.x] Migrate to v3 of intervention/image and Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/container": "^10.0|^11.0",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
         "intervention/image": "^3.4",
+        "illuminate/container": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "ext-fileinfo": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0",
-        "intervention/image": "^2.7|^3.4",
         "illuminate/container": "^10.0|^11.0",
         "illuminate/contracts": "^10.0|^11.0",
+        "intervention/image": "^3.4",
         "ext-fileinfo": "*"
     },
     "require-dev": {

--- a/src/ImageSanitize.php
+++ b/src/ImageSanitize.php
@@ -12,7 +12,8 @@ class ImageSanitize
 {
     public function __construct(
         protected PatternList $patternList,
-    ) {}
+    ) {
+    }
 
     public function detect(string $content): bool
     {

--- a/src/ImageSanitize.php
+++ b/src/ImageSanitize.php
@@ -2,17 +2,17 @@
 
 namespace LaravelAt\ImageSanitize;
 
-use Intervention\Image\Image;
+use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\EncodedImage;
+use Intervention\Image\Encoders\AutoEncoder;
 use Intervention\Image\ImageManager;
 use LaravelAt\ImageSanitize\Lists\PatternList;
 
 class ImageSanitize
 {
     public function __construct(
-        protected ImageManager $imageManager,
         protected PatternList $patternList,
-    ) {
-    }
+    ) {}
 
     public function detect(string $content): bool
     {
@@ -25,8 +25,12 @@ class ImageSanitize
         return false;
     }
 
-    public function sanitize(string $content): Image
+    public function sanitize(string $content): EncodedImage
     {
-        return $this->imageManager->make($content)->encode(null, 100);
+        $imageManager = new ImageManager(new Driver());
+
+        $image = $imageManager->read($content);
+
+        return $image->encode(new AutoEncoder(quality: 100));
     }
 }


### PR DESCRIPTION
Resolves https://github.com/laravel-at/laravel-image-sanitize/issues/23

This is a major version bump as it drops support for `intervention/image` version `2.x`.

Also adds support for Laravel v12

**Links**
https://image.intervention.io/v3/introduction/upgrade
https://image.intervention.io/v3/basics/instantiation#reading-image-sources
https://image.intervention.io/v3/basics/image-output#encoding-images
