### PR TITLE
Laravel 13 and bump PHP minimum to 8.3

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: ['12.*']
+        php: [8.3, 8.4, 8.5]
+        laravel: ['12.*', '13.*']
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - *
+      - '**'
   pull_request:
     types:
       - ready_for_review

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,16 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/support": "^12.0",
+        "php": "^8.3",
+        "illuminate/support": "^12.0|^13.0",
         "intervention/image": "^3.4",
-        "illuminate/container": "^12.0",
-        "illuminate/contracts": "^12.0",
+        "illuminate/container": "^12.0|^13.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "ext-fileinfo": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "^10.0"
+        "laravel/framework": "13",
+        "orchestra/testbench": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,10 +20,12 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
+    </source>
+    <coverage>
         <report>
             <html outputDirectory="build/coverage"/>
             <text outputFile="build/coverage.txt"/>

--- a/tests/ImageSanitizeFacadeTest.php
+++ b/tests/ImageSanitizeFacadeTest.php
@@ -3,10 +3,11 @@
 namespace LaravelAt\ImageSanitize\Tests;
 
 use ImageSanitize;
+use PHPUnit\Framework\Attributes\Test;
 
 class ImageSanitizeFacadeTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_provides_a_facade()
     {
         $content = file_get_contents(__DIR__.'/stubs/exploit.jpeg');

--- a/tests/ImageSanitizeTest.php
+++ b/tests/ImageSanitizeTest.php
@@ -3,10 +3,11 @@
 namespace LaravelAt\ImageSanitize\Tests;
 
 use LaravelAt\ImageSanitize\ImageSanitize;
+use PHPUnit\Framework\Attributes\Test;
 
 class ImageSanitizeTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_detects_embedded_malicious_code()
     {
         $content = file_get_contents(__DIR__.'/stubs/exploit.jpeg');
@@ -16,7 +17,7 @@ class ImageSanitizeTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_removes_malicious_code()
     {
         $content = file_get_contents(__DIR__.'/stubs/exploit.jpeg');

--- a/tests/RequestHandlerTest.php
+++ b/tests/RequestHandlerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use LaravelAt\ImageSanitize\ImageSanitize;
 use LaravelAt\ImageSanitize\RequestHandler;
+use PHPUnit\Framework\Attributes\Test;
 
 class RequestHandlerTest extends TestCase
 {
@@ -27,7 +28,7 @@ class RequestHandlerTest extends TestCase
         $this->sanitizer = $this->app->make(ImageSanitize::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_images_in_the_request(): void
     {
         $request = new Request;
@@ -45,7 +46,7 @@ class RequestHandlerTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_swaps_the_file_content_with_the_sanitized_string(): void
     {
         $uploadedFile = UploadedFile::fake()->image('malicious.jpeg', '100', '100');


### PR DESCRIPTION
This may have to be a major version bump as it's increasing PHP? Laravel 13 dropped support for 8.2 I believe.

- Support for Laravel 13
- Added Laravel 13 and PHP 8.5 to test matrix
- Bumped minimum PHP to 8.3
- Swapped to test attribute as `/** @test */` in docblocks is no longer supported as of PHPUnit 12. Methods must either be named test*, or use the #[Test] attribute.
- PHPUnit 13 emitted "No filter is configured, code coverage will not be processed" because coverage filters must live under <source>, not <coverage><include> (schema changed in PHPUnit 10+)